### PR TITLE
fix: use FirstName instead of Username

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ RULES:
 	}
 	for _, e := range msg.NewChatMembers {
 
-		joinedUser := e.Firstname
+		joinedUser := e.FirstName
 		systemInstructionNewJoiningUser := &genai.Content{
 			Role: "user",
 			Parts: []*genai.Part{

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ RULES:
 	}
 	for _, e := range msg.NewChatMembers {
 
-		joinedUser := e.Username
+		joinedUser := e.Firstname
 		systemInstructionNewJoiningUser := &genai.Content{
 			Role: "user",
 			Parts: []*genai.Part{


### PR DESCRIPTION
*helps avoid the bot tripping when it doesn't find actual usernames of the user *
first PR had case sensitivity issues