### PR TITLE
fix: use FirstName for welcome messages instead of Username

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ RULES:
 	}
 	for _, e := range msg.NewChatMembers {
 
-		joinedUser := e.Username
+		joinedUser := e.FirstName
 		systemInstructionNewJoiningUser := &genai.Content{
 			Role: "user",
 			Parts: []*genai.Part{


### PR DESCRIPTION
Bot is now able to pick up users Firstname and properly welcome them